### PR TITLE
Change typo in source file

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ You of course also need to install the `aspell` binary. All major linux distribu
 
 ## Configuration
 
-For seamless ispell integration, I recommend setting the following variables:
+For steamless ispell integration, I recommend setting the following variables:
 
 ```elisp
 (setq ispell-dictionary "some_dictionary"

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 Note: this file is auto converted from flycheck-aspell.el by [el2org](https://github.com/tumashu/el2org), please do not edit it by hand!!!
 
-- [flycheck-aspell](#orgddf9925)
-  - [Installation](#orgb225028)
-  - [Usage](#org58040f2)
-  - [Configuration](#org8702446)
-  - [Features](#orga420590)
+- [flycheck-aspell](#org24a0f1a)
+  - [Installation](#orge30dece)
+  - [Usage](#org1352d2e)
+  - [Configuration](#org4a048bd)
+  - [Features](#org02f84ff)
 
 
-<a id="orgddf9925"></a>
+<a id="org24a0f1a"></a>
 
 # flycheck-aspell
 
@@ -20,18 +20,18 @@ It is a successor (and complete rewrite) to my [flycheck-hunspell](https://githu
 Aspell also seems to be a bit more flexible than hunspell with regard to filters, which might prove to be useful in the future.
 
 
-<a id="orgb225028"></a>
+<a id="orge30dece"></a>
 
 ## Installation
 
 I recommend using [straight.el](https://github.com/raxod502/straight.el) for installing non-(m)elpa sources.
 
 
-<a id="org58040f2"></a>
+<a id="org1352d2e"></a>
 
 ## Usage
 
-Simply register your preferred checkers with flycheck and then start `flycheck-mode` in the buffer you would like to spell-check. (see [1.4](#orga420590) for supported filetypes)
+Simply register your preferred checkers with flycheck and then start `flycheck-mode` in the buffer you would like to spell-check. (see [1.4](#org02f84ff) for supported filetypes)
 
 ```elisp
 (require 'flycheck-aspell)
@@ -45,11 +45,11 @@ It might be wise to skim the [flycheck docs](https://www.flycheck.org/en/latest/
 You of course also need to install the `aspell` binary. All major linux distributions package it and there's probably a working macport or something.
 
 
-<a id="org8702446"></a>
+<a id="org4a048bd"></a>
 
 ## Configuration
 
-For steamless ispell integration, I recommend setting the following variables:
+For seamless ispell integration, I recommend setting the following variables:
 
 ```elisp
 (setq ispell-dictionary "some_dictionary"
@@ -69,7 +69,7 @@ You may also want to advice \`ispell-pdict-save\` for instant feedback when inse
 ```
 
 
-<a id="orga420590"></a>
+<a id="org02f84ff"></a>
 
 ## TODO Features
 

--- a/flycheck-aspell.el
+++ b/flycheck-aspell.el
@@ -68,7 +68,7 @@
 
 ;; ** Configuration
 
-;; For steamless ispell integration, I recommend setting the following variables:
+;; For seamless ispell integration, I recommend setting the following variables:
 
 ;; #+begin_src elisp
 ;; (setq ispell-dictionary "some_dictionary"


### PR DESCRIPTION
Reverts leotaku/flycheck-aspell#1

I'm stupid and merged this without thinking, of course I should edit my source file and then recompile my README.